### PR TITLE
only add href to panel anchor if id is set

### DIFF
--- a/src/Panel.js
+++ b/src/Panel.js
@@ -201,7 +201,7 @@ let Panel = React.createClass({
   renderAnchor(header, headerRole) {
     return (
       <a
-        href={'#' + (this.props.id || '')}
+        href={this.props.id && ('#' + this.props.id)}
         aria-controls={this.props.collapsible ? this.props.id : null}
         className={this.isExpanded() ? null : 'collapsed'}
         aria-expanded={this.isExpanded()}

--- a/test/PanelSpec.js
+++ b/test/PanelSpec.js
@@ -105,6 +105,15 @@ describe('Panel', () => {
     assert.equal(anchor.getAttribute('href'), '#testid');
   });
 
+  it('Should not add href if no id is passed', () => {
+    let instance = ReactTestUtils.renderIntoDocument(
+      <Panel collapsible={true} header="Heading">Panel content</Panel>
+    );
+    assert.notOk(ReactDOM.findDOMNode(instance).id);
+    let anchor = ReactDOM.findDOMNode(instance).querySelector('.panel-title a');
+    assert.equal(anchor.getAttribute('href'), undefined);
+  });
+
   it('Should be open', () => {
     let instance = ReactTestUtils.renderIntoDocument(
       <Panel collapsible={true} expanded={true} header="Heading">Panel content</Panel>


### PR DESCRIPTION
This prevents unintentional # jump behaviour id no id is set on the panel.
This should be more or less in line with what's being done in the base repo.
